### PR TITLE
Playback support. Fixes #9.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 css
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -1,170 +1,200 @@
-// Node/npm deps
-var express = require('express');
-var config = require('./config.json');
-var dust = require('dustjs-linkedin');
-var cons = require('consolidate');
-var port = process.env.PORT || 3000;
-var env = process.env.NODE_ENV || 'development';
-var GA = process.env.GA || '';
-var rooms = [];
-
-// Initialize app
-var app = express();
-var http = require('http').Server(app);
-var io = require('socket.io')(http);
-
-
-// Expose static assets
-app.use(express.static(__dirname + '/public', {redirect: false}));
-
-
-// Main app URL
-app.get('/', function(req, res){
-  cons.dust('views/index.dust', {
-    GA: GA
-  }, function (err, out) {
-    if (err) {console.error(err); }
-    res.send(out);
-  });
-});
-
-/**
- * Someone connected.
- */
-io.on('connection', function(socket){
-  console.log('user: connected');
+(function () {
+  var express = require('express'),
+      app = express(),
+      server = require('http').Server(app),
+      io = require('socket.io')(server),
+      debug = require('debug')('bustashape'),
+      redis = require('redis'),
+      client = redis.createClient(),
+      dust = require('dustjs-linkedin'),
+      cons = require('consolidate'),
+      config = require('./config.json'),
+      rooms = [];
 
   /**
-   * A user is joining a room.
+   * Setup Express to serve the index
    */
-  socket.on('join', function(data, fn) {
-    // Sanitize input.
-    var client = {};
-    var nickname = (data.nick) ? data.nick.toLowerCase().replace(/[^\d\w- ]+/gi, '') : false;
-    var roomName = (data.room) ? data.room.toLowerCase().replace(/[^\d\w-]+/gi, '') : false;
-
-    // Force a nickname.
-    if (!nickname) {
-      // The client will see `false` and alert this message.
-      fn( false, 'Please pick a nickname.' );
-      return;
-    }
-
-    // Join the requested room or create it.
-    if (!roomName) {
-      // Generate strings until a room name is found.
-      var attempts = 0;
-      while ( !roomName && (rooms[roomName] !== 'undefined') ) {
-        if ( attempts < 5 ) {
-          roomName = config.rooms[Math.floor(Math.random() * config.rooms.length)];
-        } else {
-          // We've failed to get a friendly room name. Just make a random string.
-          roomName = Math.floor(Math.random() * 100000);
-        }
-        attempts++;
-      }
-    }
-
-    // Set up the room
-    if (typeof(rooms[roomName]) === 'undefined') {
-      // This room is new. Create the array in the room.
-      rooms[roomName] = [];
-    } else {
-      // This game exists, check for duplicate names
-      for ( client in rooms[roomName] ) {
-        if (nickname == rooms[roomName][client].nick ) {
-          fn( false, 'Nickname already in use.' );
-          return;
-        }
-      }
-    }
-
-    // Store the room name.
-    socket.room = roomName;
-
-    // Log the event.
-    console.log('user: %s is joining %s', nickname, roomName);
-
-    // List user as a member of the room.
-    client = {
-      sid: socket.id,
-      nick: nickname,
-      room: roomName
-    };
-    rooms[roomName].push(client);
-
-    // Join room
-    socket.join(roomName);
-
-    // Tell others that this person joined.
-    socket.broadcast.in(roomName).emit('user-joined', {
-      'nick': client.nick,
-      'sid' : client.sid
-    });
-
-    // Callback
-    fn(true, {
-      'sid': client.sid,
-      'nick': nickname,
-      'room': roomName,
-      'users': rooms[roomName]
-    });
-  });
-
-
-  /**
-   * A new shape appears!
-   */
-  socket.on('add', function(props){
-    console.log('ADD', props);
-    io.to(socket.room).emit('add', props);
-  });
-
-  /**
-   * A shape is being changed.
-   */
-  socket.on('change', function(props){
-    console.log('CHANGE', socket.room, props);
-    socket.broadcast.to(socket.room).emit('change', props);
-  });
-
-  /**
-   * Someone got bored.
-   */
-  socket.on('disconnect', function() {
-    // Get current room
-    var room = socket.room;
-
-    if ( !room ) {
-      // No room was found. The server probably restarted so just bail.
-      return false;
-    }
-
-    /* Iterate over the bucket _backwards_ so we can cleanly remove the departing
-     * client having to recalculate the length (as you would in a for loop) */
-    var i = rooms[room].length;
-    while (i--) {
-      if (rooms[room][i].sid == socket.id) {
-        var client = rooms[room][i];
-        rooms[room].splice(i, 1);
-
-        // This data is safe to send out since it's coming from the stored
-        // rooms, not the incoming socket data.
-        socket.broadcast.emit('client-disconnect', {
-          'nick': client.nick,
-          'sid' : client.sid
+  app
+    .use(express.static(__dirname + '/public', {redirect: false}))
+    .get('/', function (req, res){
+      cons
+        .dust('views/index.dust', { GA: process.env.GA || ''}, function (err, out) {
+          if (err) {
+            debug(err);
+            return res.send(err);
+          }
+          return res.send(out);
         });
-
-        // Log the event.
-        console.log("Shucks. %s disconnected..", client.nick);
+    })
+    .get('/playback', function (req, res) {
+      if (req.query.hasOwnProperty('room') && req.query.room !== ''){
+        client.lrange(req.query.room, 0, 999, function (err, replies) {
+          res.send(replies.map(function (e) {
+            return JSON.parse(e);
+          }));
+        })
       }
-    }
-  });
-});
+    });
 
-/**
- * Listen for users to connect
- */
-http.listen(port, function(){
-  console.log('Listening on port ' + port);
-});
+  /**
+   * Someone connected.
+   */
+  io.on('connection', function (socket) {
+    debug('user: connected');
+
+    /**
+     * A user is joining a room.
+     */
+    socket.on('join', function (data, fn) {
+      // Sanitize input.
+      var client = {},
+          nickname = (data.nick) ? data.nick.toLowerCase().replace(/[^\d\w- ]+/gi, '') : false,
+          roomName = (data.room) ? data.room.toLowerCase().replace(/[^\d\w-]+/gi, '') : false;
+
+      // Force a nickname.
+      if (!nickname) {
+        // The client will see `false` and alert this message.
+        fn(false, 'Please pick a nickname.');
+        return;
+      }
+
+      // Join the requested room or create it.
+      if (!roomName) {
+        // Generate strings until a room name is found.
+        var attempts = 0;
+        while (!roomName && (rooms[roomName] !== 'undefined')) {
+          if (attempts < 5) {
+            roomName = config.rooms[Math.floor(Math.random() * config.rooms.length)];
+          }
+          else {
+            // We've failed to get a friendly room name. Just make a random string.
+            roomName = Math.floor(Math.random() * 100000);
+          }
+          attempts++;
+        }
+      }
+
+      // Set up the room
+      if (typeof(rooms[roomName]) === 'undefined') {
+        // This room is new. Create the array in the room.
+        rooms[roomName] = [];
+      } else {
+        // This game exists, check for duplicate names
+        for ( client in rooms[roomName] ) {
+          if (nickname == rooms[roomName][client].nick ) {
+            fn(false, 'Nickname already in use.');
+            return;
+          }
+        }
+      }
+
+      // Store the room name.
+      socket.room = roomName;
+
+      // Log the event.
+      debug('user: %s is joining %s', nickname, roomName);
+
+      // List user as a member of the room.
+      client = {
+        sid: socket.id,
+        nick: nickname,
+        room: roomName
+      };
+
+      rooms[roomName].push(client);
+
+      // Join room
+      socket.join(roomName);
+
+      // Tell others that this person joined.
+      socket.broadcast.in(roomName).emit('user-joined', {
+        'nick': client.nick,
+        'sid' : client.sid
+      });
+
+      // Callback
+      fn(true, {
+        'sid': client.sid,
+        'nick': nickname,
+        'room': roomName,
+        'users': rooms[roomName]
+      });
+    });
+
+
+    /**
+     * A new shape appears!
+     */
+    socket.on('add', function (props) {
+      debug('ADD', props);
+      io.to(socket.room).emit('add', props);
+      client.multi([
+        ['rpush', socket.room, JSON.stringify(props)],
+        ['ltrim', socket.room, 0, 999]
+      ]).exec(function (error, replies) {
+        if (error) {
+          debug('Unable to store this action in Redis.');
+        }
+      });
+    });
+
+    /**
+     * A shape is being changed.
+     */
+    socket.on('change', function (props) {
+      debug('CHANGE', socket.room, props);
+      socket.broadcast.to(socket.room).emit('change', props);
+      client.multi([
+        ['rpush', socket.room, JSON.stringify(props)],
+        ['ltrim', socket.room, 0, 999]
+      ]).exec(function (error, replies) {
+        if (error) {
+          debug('Unable to store this action in Redis.');
+        }
+      });
+    });
+
+    /**
+     * Someone got bored.
+     */
+    socket.on('disconnect', function() {
+      // Get current room
+      var room = socket.room,
+          i;
+
+      if (!room) {
+        // No room was found. The server probably restarted so just bail.
+        return false;
+      }
+
+      /* Iterate over the bucket _backwards_ so we can cleanly remove the departing
+       * client having to recalculate the length (as you would in a for loop) */
+      i = rooms[room].length;
+      while (i--) {
+        if (rooms[room][i].sid == socket.id) {
+          var client = rooms[room][i];
+          rooms[room].splice(i, 1);
+
+          // This data is safe to send out since it's coming from the stored
+          // rooms, not the incoming socket data.
+          socket.broadcast.emit('client-disconnect', {
+            'nick': client.nick,
+            'sid' : client.sid
+          });
+
+          // Log the event.
+          debug("Shucks. %s disconnected..", client.nick);
+        }
+      }
+    });
+  });
+
+  /**
+   * Listen for users to connect
+   */
+  server.listen(process.env.PORT || 3000, function(){
+    debug('Listening on %s ', process.env.PORT || 3000);
+  });
+
+  return server;
+})();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "browser-sync": "^2.7.6",
     "consolidate": "^0.13.1",
+    "debug": "^2.2.0",
     "dustjs-linkedin": "^2.7.2",
     "express": "^4.12.4",
     "gulp": "^3.9.0",
@@ -14,6 +15,7 @@
     "gulp-nodemon": "^2.0.3",
     "gulp-sass": "^2.0.1",
     "gulp-util": "^3.0.5",
+    "redis": "^0.12.1",
     "socket.io": "^1.3.5"
   },
   "engines": {
@@ -21,6 +23,6 @@
   },
   "scripts": {
     "postinstall": "gulp sass",
-    "start": "node index.js"
+    "start": "DEBUG=bustashape node index.js"
   }
 }


### PR DESCRIPTION
Opening a PR based on @mattgrill's fine work.

I think we need to hide some of this behind a config flag so we can easily control how/when it's used. I also need to make sure Heroku is set up right before deploying this.
- Scenario 1: "instant mode" would bring a user to the current state of things immediately upon login. Ideally we'd poll Redis and just grab the last known state of each shape. All shapes are instantly interactive as if the person has been there all along.
- Scenario 2: "observer mode" would play it back in real-time. The user would not be able to grab stuff until we reach the end. This mode isn't built yet but the data is theoretically being collected when this PR is merged.
