### PR TITLE
Tighten up menu so that skinnier phones display one line

### DIFF
--- a/sass/partials/_controls.scss
+++ b/sass/partials/_controls.scss
@@ -17,7 +17,7 @@
   // Space the labels/buttons out a bit
   label, button {
     display: inline-block;
-    padding: .5em .4em;
+    padding: .5em .2em;
     user-select: none;
     text-transform: lowercase;
     cursor: pointer;
@@ -39,6 +39,14 @@
     //
     // @see https://adactio.com/journal/10019
     touch-action: manipulation;
+
+    // Space out the menu on larger screens.
+    //
+    // @TODO: replace with flexbox
+    @media (min-width: 360px) {
+      padding-left: .4em;
+      padding-right: .4em;
+    }
   }
 
   // Hide controls by default. Holding finger on label toggles visibility.
@@ -114,9 +122,9 @@
   button {
     font-size: 1.2em;
     width: 1.8em;
-    height: 2em;
+    height: 1.5em;
     margin: 0 .25em;
-    padding: .4em .7em;
+    padding: .2em .3em;
     border: none;
     border-radius: 3px;
     background: unset;
@@ -128,7 +136,7 @@
 
   // Toggle button
   #toggle {
-    width: 2.4em;
+    width: 1.7em;
     margin-left: 0;
     opacity: 1;
     position: relative;
@@ -136,7 +144,7 @@
 
     // Spice up the button with effects.
     white-space: nowrap;
-    text-indent: -1.5em;
+    text-indent: -1em;
 
     // Transition effects.
     transition: background-color .2s ease-in-out,
@@ -153,7 +161,7 @@
     .open, .cancel {
       display: inline-block;
       text-align: left;
-      width: 3em;
+      width: 2em;
     }
 
     .open {


### PR DESCRIPTION
Ideally, we want less than 320px to fit the most common screen sizes (iPhone 5 and older, MotoE, etc)
