### PR TITLE
Re-implement popping animation for new shapes

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -48,6 +48,7 @@ socket.on('add', function(props) {
 
   // Draw shape for first time.
   two.update();
+  shape._renderer.elem.classList.add('unchanged');
 
   if (debug_busta === true) {
     debugShape(shape);

--- a/sass/partials/_shapes.scss
+++ b/sass/partials/_shapes.scss
@@ -1,6 +1,14 @@
 //------------------------------------------------------------------------------
 // Shapes
 //------------------------------------------------------------------------------
+$start-WIDTH: 200;
+$start-HEIGHT: 200;
+$start-RADIUS: 100;
+$start-X: $start-WIDTH / 2;
+$start-Y: $start-HEIGHT / 2;
+$start-SCALE: 1;
+$start-ANGLE: 0;
+
 
 //
 // Unchanged
@@ -9,14 +17,14 @@
 // until being touched for the first time.
 .unchanged {
   // pop-in effect
-  transform: scale(0);
+  transform: translate($start-X, $start-Y) scale(0);
   animation: appear .33333s $snap-1;
   animation-fill-mode: forwards;
 }
 
 @keyframes appear {
   100% {
-    transform: scale(1);
+    transform: translate($start-X, $start-Y) scale(1);
   }
 }
 


### PR DESCRIPTION
When I merged #21 I intentionally excluded the popping animation that new shapes had when they were basic DOM elements. I'm sure two.js can do this somehow, just need to move the code from CSS to JS.
