### PR TITLE
New shapes should be relative to current state of canvas

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,6 +80,7 @@ gulp.task('js', function() {
 
   var ui = gulp.src([
     'node_modules/two.js/build/two.js',
+    'js/tween-old.js',
     'js/client.js',
     'js/canvas.js',
     'js/controls.js',

--- a/js/canvas.js
+++ b/js/canvas.js
@@ -49,6 +49,9 @@ if (Modernizr.touchevents) {
   // calculation that only pans the canvas instead of zooming it as well.
   //
   function changeCanvas(ev) {
+    // Negate default gestures (e.g. pinch-to-select tabs in iPad Safari)
+    ev.preventDefault();
+
     if (ev.type === 'pinchstart' && ev.target === svg) {
       scene_transform.initScale = n(scene_transform.scale) || 1;
       scene_transform.initCenter.x = n(scene_transform.center.x) || ev.center.x;
@@ -100,9 +103,6 @@ if (Modernizr.touchevents) {
         scene_transform.ticking = true;
       }
     }
-
-    // negate default gestures (e.g. pinch-to-select tabs in iPad Safari)
-    ev.preventDefault();
   }
 }
 

--- a/js/canvas.js
+++ b/js/canvas.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var ZOOM_LIMIT = 1000;
 var scene_transform = {
   ticking: false,
   initX: 0,
@@ -72,6 +73,14 @@ if (Modernizr.touchevents) {
       // First, capture the new scale. This is a basic operation that comes
       // directly from the event data.
       scene_transform.scale = scene_transform.initScale * ev.scale;
+
+      // Limit scaling to avoid getting lost.
+      if (scene_transform.scale < 1 / ZOOM_LIMIT) {
+        scene_transform.scale = 1 / ZOOM_LIMIT;
+      }
+      if (scene_transform.scale > ZOOM_LIMIT) {
+        scene_transform.scale = ZOOM_LIMIT;
+      }
 
       // Next, calculate the origin for this scale transform.
       scene_transform.center.x = /*scene_transform.initCenter.x -*/ ev.center.x;

--- a/js/client.js
+++ b/js/client.js
@@ -4,8 +4,15 @@ var logged_in = false;
 
 // Initialize two.js
 var canvas = $('#canvas');
-var params = { width: '100%', height: '100%' };
-var two = new Two(params).appendTo(canvas);
+var two = new Two({
+  fullscreen: true,
+  autostart: true
+}).appendTo(canvas);
+
+// Allow tweening to run continuously.
+two.bind('update', function twoUpdateListener() {
+  TWEEN.update();
+});
 
 // debug
 if (debug_busta === true) {
@@ -26,7 +33,7 @@ var START_ANGLE = 0;
  * Listen for new shapes and add them to DOM.
  */
 socket.on('add', function(props) {
-  // console.debug(props);
+  // Close all form controls that might be open.
   unFocus();
 
   // Create new shape
@@ -46,16 +53,28 @@ socket.on('add', function(props) {
   shape.opacity = props.opacity;
   shape.noStroke();
 
-  // Draw shape for first time.
+  // Set pre-popping size. This will be animated to the "default" settings.
+  shape.scale = 1 / 4;
+
+  // Popping animation
+  // @see https://jsfiddle.net/jonobr1/72bytkhm/
+  var pop = new TWEEN.Tween(shape)
+    .to({
+      scale: 1
+    }, 400)
+    .easing(TWEEN.Easing.Elastic.Out)
+    .start();
+
+  // Draw shape for first time at scale(0) so we can run the popping animation
+  // and apply the advanced CSS props (e.g. blend mode).
   two.update();
-  shape._renderer.elem.classList.add('unchanged');
 
   if (debug_busta === true) {
     debugShape(shape);
   }
 
   // Reference DOM element to allow direct manipulation for a few things.
-  var el = document.getElementById(shape.id);
+  var el = shape._renderer.elem;
   el.style.mixBlendMode = props.mixBlendMode;
 
   // Set up Hammer. Also uses direct DOM node.

--- a/js/client.js
+++ b/js/client.js
@@ -20,12 +20,8 @@ if (debug_busta === true) {
 }
 
 // Define some constants for two.js
-var START_WIDTH = 200; // start width
-var START_HEIGHT = 200; // start height
-var START_RADIUS = 100; // start size radius
-var START_X = START_WIDTH / 2;
-var START_Y = START_HEIGHT / 2;
-var START_SCALE = 1;
+var START_WIDTH = 200;
+var START_HEIGHT = 200;
 var START_ANGLE = 0;
 
 
@@ -36,13 +32,16 @@ socket.on('add', function(props) {
   // Close all form controls that might be open.
   unFocus();
 
+  var START_X = n(props.x);
+  var START_Y = n(props.y);
+
   // Create new shape
   if (props.class === 'circle') {
-    var shape = two.makeCircle(START_X, START_Y, START_RADIUS);
+    var shape = two.makeCircle(START_X, START_Y, START_WIDTH / 2);
   } else if (props.class === 'rectangle') {
-    var shape = two.makeRectangle(START_X, START_Y, START_WIDTH*2, START_HEIGHT);
+    var shape = two.makeRectangle(START_X, START_Y, START_WIDTH * 2, START_HEIGHT);
   } else if (props.class === 'triangle') {
-    var shape = two.makePolygon(START_X, START_Y, START_WIDTH/1.5, 3);
+    var shape = two.makePolygon(START_X, START_Y, START_WIDTH / 1.5, 3);
   } else {
     var shape = two.makeRectangle(START_X, START_Y, START_WIDTH, START_HEIGHT);
   }
@@ -54,13 +53,13 @@ socket.on('add', function(props) {
   shape.noStroke();
 
   // Set pre-popping size. This will be animated to the "default" settings.
-  shape.scale = 1 / 4;
+  shape.scale = props.scale / 4;
 
   // Popping animation
   // @see https://jsfiddle.net/jonobr1/72bytkhm/
   var pop = new TWEEN.Tween(shape)
     .to({
-      scale: 1
+      scale: props.scale
     }, 400)
     .easing(TWEEN.Easing.Elastic.Out)
     .start();
@@ -81,15 +80,13 @@ socket.on('add', function(props) {
   var mc = new Hammer.Manager(el);
   var initX;
   var initY;
-  var initAngle = START_ANGLE;
-  var initScale = START_SCALE;
   var timer;
   var ticking = false;
   var transform = {
-    x: START_X,
-    y: START_Y,
-    scale: initScale,
-    angle: initAngle,
+    x: props.x,
+    y: props.y,
+    angle: START_ANGLE,
+    scale: props.scale,
   };
 
 

--- a/js/controls.js
+++ b/js/controls.js
@@ -20,6 +20,16 @@ $$('.proto').forEach(function (el) {
 // shape options, there is a different set of actions executed.
 //
 function createShape(ev) {
+  // New shape position
+  //
+  // Shapes get lost when the user doesn't see them immediately. New shapes
+  // should appear in the center of the user's viewport so it's noticeable when
+  // it appears. The numbers generated here are relative to scene_transform, so
+  // they will appear in the correct place on all other screens as well.
+  var REL_SCALE = 1 / scene_transform.scale;
+  var REL_X = Math.floor((-scene_transform.x + (two.width / 2)) / scene_transform.scale);
+  var REL_Y = Math.floor((-scene_transform.y + (two.height / 2)) / scene_transform.scale);
+
   // Set button to active so it's obvious that it was pressed. The incoming
   // socket event will unset this class.
   this.classList.add('active');
@@ -32,7 +42,10 @@ function createShape(ev) {
     opacity: this.dataset.opacity,
     color: this.dataset.color,
     borderColor: this.dataset.color,
-    mixBlendMode: this.dataset.blend
+    mixBlendMode: this.dataset.blend,
+    x: REL_X,
+    y: REL_Y,
+    scale: REL_SCALE,
   });
   ev.preventDefault();
 }

--- a/js/tween-old.js
+++ b/js/tween-old.js
@@ -1,0 +1,623 @@
+/**
+ * @author sole / http://soledadpenades.com
+ * @author mr.doob / http://mrdoob.com
+ * @author Robert Eisele / http://www.xarg.org
+ * @author Philippe / http://philippe.elsass.me
+ * @author Robert Penner / http://www.robertpenner.com/easing_terms_of_use.html
+ * @author Paul Lewis / http://www.aerotwist.com/
+ * @author lechecacharro
+ * @author Josh Faul / http://jocafa.com/
+ * @author egraether / http://egraether.com/
+ */
+
+var TWEEN = TWEEN || ( function () {
+
+  var _tweens = [];
+
+  return {
+
+    REVISION: '6',
+
+    getAll: function () {
+
+      return _tweens;
+
+    },
+
+    removeAll: function () {
+
+      _tweens = [];
+
+    },
+
+    add: function ( tween ) {
+
+      _tweens.push( tween );
+
+    },
+
+    remove: function ( tween ) {
+
+      var i = _tweens.indexOf( tween );
+
+      if ( i !== -1 ) {
+
+        _tweens.splice( i, 1 );
+
+      }
+
+    },
+
+    update: function ( time ) {
+
+      var i = 0;
+      var num_tweens = _tweens.length;
+      var time = time !== undefined ? time : Date.now();
+
+      while ( i < num_tweens ) {
+
+        if ( _tweens[ i ].update( time ) ) {
+
+          i ++;
+
+        } else {
+
+          _tweens.splice( i, 1 );
+          num_tweens --;
+
+        }
+
+      }
+
+    }
+
+  };
+
+} )();
+
+TWEEN.Tween = function ( object ) {
+
+  var _object = object;
+  var _valuesStart = {};
+  var _valuesEnd = {};
+  var _duration = 1000;
+  var _delayTime = 0;
+  var _startTime = null;
+  var _easingFunction = TWEEN.Easing.Linear.None;
+  var _interpolationFunction = TWEEN.Interpolation.Linear;
+  var _chainedTween = null;
+  var _onUpdateCallback = null;
+  var _onCompleteCallback = null;
+
+  this.to = function ( properties, duration ) {
+
+    if ( duration !== null ) {
+
+      _duration = duration;
+
+    }
+
+    _valuesEnd = properties;
+
+    return this;
+
+  };
+
+  this.start = function ( time ) {
+
+    TWEEN.add( this );
+
+    _startTime = time !== undefined ? time : Date.now();
+    _startTime += _delayTime;
+
+    for ( var property in _valuesEnd ) {
+
+      // This prevents the engine from interpolating null values
+      if ( _object[ property ] === null ) {
+
+        continue;
+
+      }
+
+      // check if an Array was provided as property value
+      if ( _valuesEnd[ property ] instanceof Array ) {
+
+        if ( _valuesEnd[ property ].length === 0 ) {
+
+          continue;
+
+        }
+
+        // create a local copy of the Array with the start value at the front
+        _valuesEnd[ property ] = [ _object[ property ] ].concat( _valuesEnd[ property ] );
+
+      }
+
+      _valuesStart[ property ] = _object[ property ];
+
+    }
+
+    return this;
+
+  };
+
+  this.stop = function () {
+
+    TWEEN.remove( this );
+    return this;
+
+  };
+
+  this.delay = function ( amount ) {
+
+    _delayTime = amount;
+    return this;
+
+  };
+
+  this.easing = function ( easing ) {
+
+    _easingFunction = easing;
+    return this;
+
+  };
+
+  this.interpolation = function ( interpolation ) {
+
+    _interpolationFunction = interpolation;
+    return this;
+
+  };
+
+  this.chain = function ( chainedTween ) {
+
+    _chainedTween = chainedTween;
+    return this;
+
+  };
+
+  this.onUpdate = function ( onUpdateCallback ) {
+
+    _onUpdateCallback = onUpdateCallback;
+    return this;
+
+  };
+
+  this.onComplete = function ( onCompleteCallback ) {
+
+    _onCompleteCallback = onCompleteCallback;
+    return this;
+
+  };
+
+  this.getOnComplete = function () {
+
+    return _onCompleteCallback;
+
+  };
+
+  this.update = function ( time ) {
+
+    if ( time < _startTime ) {
+
+      return true;
+
+    }
+
+    var elapsed = ( time - _startTime ) / _duration;
+    elapsed = elapsed > 1 ? 1 : elapsed;
+
+    var value = _easingFunction( elapsed );
+
+    for ( var property in _valuesStart ) {
+
+      var start = _valuesStart[ property ];
+      var end = _valuesEnd[ property ];
+
+      if ( end instanceof Array ) {
+
+        _object[ property ] = _interpolationFunction( end, value );
+
+      } else {
+
+        _object[ property ] = start + ( end - start ) * value;
+
+      }
+
+    }
+
+    if ( _onUpdateCallback !== null ) {
+
+      _onUpdateCallback.call( _object, value );
+
+    }
+
+    if ( elapsed == 1 ) {
+
+      if ( _onCompleteCallback !== null ) {
+
+        _onCompleteCallback.call( _object );
+
+      }
+
+      if ( _chainedTween !== null ) {
+
+        _chainedTween.start();
+
+      }
+
+      return false;
+
+    }
+
+    return true;
+
+  };
+
+};
+
+TWEEN.Easing = {
+
+  Linear: {
+
+    None: function ( k ) {
+
+      return k;
+
+    }
+
+  },
+
+  Quadratic: {
+
+    In: function ( k ) {
+
+      return k * k;
+
+    },
+
+    Out: function ( k ) {
+
+      return k * ( 2 - k );
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( ( k *= 2 ) < 1 ) return 0.5 * k * k;
+      return - 0.5 * ( --k * ( k - 2 ) - 1 );
+
+    }
+
+  },
+
+  Cubic: {
+
+    In: function ( k ) {
+
+      return k * k * k;
+
+    },
+
+    Out: function ( k ) {
+
+      return --k * k * k + 1;
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( ( k *= 2 ) < 1 ) return 0.5 * k * k * k;
+      return 0.5 * ( ( k -= 2 ) * k * k + 2 );
+
+    }
+
+  },
+
+  Quartic: {
+
+    In: function ( k ) {
+
+      return k * k * k * k;
+
+    },
+
+    Out: function ( k ) {
+
+      return 1 - --k * k * k * k;
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( ( k *= 2 ) < 1) return 0.5 * k * k * k * k;
+      return - 0.5 * ( ( k -= 2 ) * k * k * k - 2 );
+
+    }
+
+  },
+
+  Quintic: {
+
+    In: function ( k ) {
+
+      return k * k * k * k * k;
+
+    },
+
+    Out: function ( k ) {
+
+      return --k * k * k * k * k + 1;
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( ( k *= 2 ) < 1 ) return 0.5 * k * k * k * k * k;
+      return 0.5 * ( ( k -= 2 ) * k * k * k * k + 2 );
+
+    }
+
+  },
+
+  Sinusoidal: {
+
+    In: function ( k ) {
+
+      return 1 - Math.cos( k * Math.PI / 2 );
+
+    },
+
+    Out: function ( k ) {
+
+      return Math.sin( k * Math.PI / 2 );
+
+    },
+
+    InOut: function ( k ) {
+
+      return 0.5 * ( 1 - Math.cos( Math.PI * k ) );
+
+    }
+
+  },
+
+  Exponential: {
+
+    In: function ( k ) {
+
+      return k === 0 ? 0 : Math.pow( 1024, k - 1 );
+
+    },
+
+    Out: function ( k ) {
+
+      return k === 1 ? 1 : 1 - Math.pow( 2, - 10 * k );
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( k === 0 ) return 0;
+      if ( k === 1 ) return 1;
+      if ( ( k *= 2 ) < 1 ) return 0.5 * Math.pow( 1024, k - 1 );
+      return 0.5 * ( - Math.pow( 2, - 10 * ( k - 1 ) ) + 2 );
+
+    }
+
+  },
+
+  Circular: {
+
+    In: function ( k ) {
+
+      return 1 - Math.sqrt( 1 - k * k );
+
+    },
+
+    Out: function ( k ) {
+
+      return Math.sqrt( 1 - --k * k );
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( ( k *= 2 ) < 1) return - 0.5 * ( Math.sqrt( 1 - k * k) - 1);
+      return 0.5 * ( Math.sqrt( 1 - ( k -= 2) * k) + 1);
+
+    }
+
+  },
+
+  Elastic: {
+
+    In: function ( k ) {
+
+      var s, a = 0.1, p = 0.4;
+      if ( k === 0 ) return 0;
+      if ( k === 1 ) return 1;
+      if ( !a || a < 1 ) { a = 1; s = p / 4; }
+      else s = p * Math.asin( 1 / a ) / ( 2 * Math.PI );
+      return - ( a * Math.pow( 2, 10 * ( k -= 1 ) ) * Math.sin( ( k - s ) * ( 2 * Math.PI ) / p ) );
+
+    },
+
+    Out: function ( k ) {
+
+      var s, a = 0.1, p = 0.4;
+      if ( k === 0 ) return 0;
+      if ( k === 1 ) return 1;
+      if ( !a || a < 1 ) { a = 1; s = p / 4; }
+      else s = p * Math.asin( 1 / a ) / ( 2 * Math.PI );
+      return ( a * Math.pow( 2, - 10 * k) * Math.sin( ( k - s ) * ( 2 * Math.PI ) / p ) + 1 );
+
+    },
+
+    InOut: function ( k ) {
+
+      var s, a = 0.1, p = 0.4;
+      if ( k === 0 ) return 0;
+      if ( k === 1 ) return 1;
+      if ( !a || a < 1 ) { a = 1; s = p / 4; }
+      else s = p * Math.asin( 1 / a ) / ( 2 * Math.PI );
+      if ( ( k *= 2 ) < 1 ) return - 0.5 * ( a * Math.pow( 2, 10 * ( k -= 1 ) ) * Math.sin( ( k - s ) * ( 2 * Math.PI ) / p ) );
+      return a * Math.pow( 2, -10 * ( k -= 1 ) ) * Math.sin( ( k - s ) * ( 2 * Math.PI ) / p ) * 0.5 + 1;
+
+    }
+
+  },
+
+  Back: {
+
+    In: function ( k ) {
+
+      var s = 1.70158;
+      return k * k * ( ( s + 1 ) * k - s );
+
+    },
+
+    Out: function ( k ) {
+
+      var s = 1.70158;
+      return --k * k * ( ( s + 1 ) * k + s ) + 1;
+
+    },
+
+    InOut: function ( k ) {
+
+      var s = 1.70158 * 1.525;
+      if ( ( k *= 2 ) < 1 ) return 0.5 * ( k * k * ( ( s + 1 ) * k - s ) );
+      return 0.5 * ( ( k -= 2 ) * k * ( ( s + 1 ) * k + s ) + 2 );
+
+    }
+
+  },
+
+  Bounce: {
+
+    In: function ( k ) {
+
+      return 1 - TWEEN.Easing.Bounce.Out( 1 - k );
+
+    },
+
+    Out: function ( k ) {
+
+      if ( k < ( 1 / 2.75 ) ) {
+
+        return 7.5625 * k * k;
+
+      } else if ( k < ( 2 / 2.75 ) ) {
+
+        return 7.5625 * ( k -= ( 1.5 / 2.75 ) ) * k + 0.75;
+
+      } else if ( k < ( 2.5 / 2.75 ) ) {
+
+        return 7.5625 * ( k -= ( 2.25 / 2.75 ) ) * k + 0.9375;
+
+      } else {
+
+        return 7.5625 * ( k -= ( 2.625 / 2.75 ) ) * k + 0.984375;
+
+      }
+
+    },
+
+    InOut: function ( k ) {
+
+      if ( k < 0.5 ) return TWEEN.Easing.Bounce.In( k * 2 ) * 0.5;
+      return TWEEN.Easing.Bounce.Out( k * 2 - 1 ) * 0.5 + 0.5;
+
+    }
+
+  }
+
+};
+
+TWEEN.Interpolation = {
+
+  Linear: function ( v, k ) {
+
+    var m = v.length - 1, f = m * k, i = Math.floor( f ), fn = TWEEN.Interpolation.Utils.Linear;
+
+    if ( k < 0 ) return fn( v[ 0 ], v[ 1 ], f );
+    if ( k > 1 ) return fn( v[ m ], v[ m - 1 ], m - f );
+
+    return fn( v[ i ], v[ i + 1 > m ? m : i + 1 ], f - i );
+
+  },
+
+  Bezier: function ( v, k ) {
+
+    var b = 0, n = v.length - 1, pw = Math.pow, bn = TWEEN.Interpolation.Utils.Bernstein, i;
+
+    for ( i = 0; i <= n; i++ ) {
+      b += pw( 1 - k, n - i ) * pw( k, i ) * v[ i ] * bn( n, i );
+    }
+
+    return b;
+
+  },
+
+  CatmullRom: function ( v, k ) {
+
+    var m = v.length - 1, f = m * k, i = Math.floor( f ), fn = TWEEN.Interpolation.Utils.CatmullRom;
+
+    if ( v[ 0 ] === v[ m ] ) {
+
+      if ( k < 0 ) i = Math.floor( f = m * ( 1 + k ) );
+
+      return fn( v[ ( i - 1 + m ) % m ], v[ i ], v[ ( i + 1 ) % m ], v[ ( i + 2 ) % m ], f - i );
+
+    } else {
+
+      if ( k < 0 ) return v[ 0 ] - ( fn( v[ 0 ], v[ 0 ], v[ 1 ], v[ 1 ], -f ) - v[ 0 ] );
+      if ( k > 1 ) return v[ m ] - ( fn( v[ m ], v[ m ], v[ m - 1 ], v[ m - 1 ], f - m ) - v[ m ] );
+
+      return fn( v[ i ? i - 1 : 0 ], v[ i ], v[ m < i + 1 ? m : i + 1 ], v[ m < i + 2 ? m : i + 2 ], f - i );
+
+    }
+
+  },
+
+  Utils: {
+
+    Linear: function ( p0, p1, t ) {
+
+      return ( p1 - p0 ) * t + p0;
+
+    },
+
+    Bernstein: function ( n , i ) {
+
+      var fc = TWEEN.Interpolation.Utils.Factorial;
+      return fc( n ) / fc( i ) / fc( n - i );
+
+    },
+
+    Factorial: ( function () {
+
+      var a = [ 1 ];
+
+      return function ( n ) {
+
+        var s = 1, i;
+        if ( a[ n ] ) return a[ n ];
+        for ( i = n; i > 1; i-- ) s *= i;
+        return a[ n ] = s;
+
+      }
+
+    } )(),
+
+    CatmullRom: function ( p0, p1, p2, p3, t ) {
+
+      var v0 = ( p2 - p0 ) * 0.5, v1 = ( p3 - p1 ) * 0.5, t2 = t * t, t3 = t * t2;
+      return ( 2 * p1 - 2 * p2 + v0 + v1 ) * t3 + ( - 3 * p1 + 3 * p2 - 2 * v0 - v1 ) * t2 + v0 * t + p1;
+
+    }
+
+  }
+
+};

--- a/sass/partials/_shapes.scss
+++ b/sass/partials/_shapes.scss
@@ -1,14 +1,6 @@
 //------------------------------------------------------------------------------
 // Shapes
 //------------------------------------------------------------------------------
-$start-WIDTH: 200;
-$start-HEIGHT: 200;
-$start-RADIUS: 100;
-$start-X: $start-WIDTH / 2;
-$start-Y: $start-HEIGHT / 2;
-$start-SCALE: 1;
-$start-ANGLE: 0;
-
 
 //
 // Unchanged
@@ -16,18 +8,7 @@ $start-ANGLE: 0;
 // When a new shape appears it is "unchanged"
 // until being touched for the first time.
 .unchanged {
-  // pop-in effect
-  transform: translate($start-X, $start-Y) scale(0);
-  animation: appear .33333s $snap-1;
-  animation-fill-mode: forwards;
 }
-
-@keyframes appear {
-  100% {
-    transform: translate($start-X, $start-Y) scale(1);
-  }
-}
-
 
 //
 // Mouse users see a grabbing cursor.


### PR DESCRIPTION
I noticed as I tested #24 that after zooming out a few times and making progressively bigger shapes, the new ones were too tiny to grab with two fingers to scale up. The new shapes should always be roughly the same size on your screen, and perhaps they should always appear in the top-left corner.

I _think_ this is as simple as checking canvas scale/translation when creating new shape, and offsetting by those amounts. But I've been known to oversimplify math before :grin: 
