### PR TITLE
Rejoin on lost connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,23 +135,23 @@ io.on('connection', function(socket){
    * A new shape appears!
    */
   socket.on('add', function(props){
-    // We use io.to() instead of socket.broadcast() because when a shape is
+    // We use io.to() instead of socket.to() because when a shape is
     // added, all clients (including the person who initiated the ADD command)
     // need to receive the ADD event in order to create the shape onscreen.
-    io.to(roomName).emit('add', props);
-    console.log('🔷💥 ', roomName, JSON.stringify(props).replace('\n',''));
+    io.to(props.room).emit('add', props);
+    console.log('🔷💥 ', JSON.stringify(props).replace('\n',''));
   });
 
   /**
    * A shape is being changed.
    */
   socket.on('change', function(props){
-    // We use socket.broadcast() instead of io.to() because when shapes are
+    // We use socket.to() instead of io.to() because when shapes are
     // changed, the client who is making the changes should NOT receive the
     // socket data. it happens locally only, and then the changes are then
     // broadcast to all other clients.
-    socket.to(roomName).emit('change', props);
-    console.log('🔷💨 ', roomName, JSON.stringify(props).replace('\n',''));
+    socket.to(props.room).emit('change', props);
+    console.log('🔷💨 ', JSON.stringify(props).replace('\n',''));
   });
 
   /**

--- a/js/client.js
+++ b/js/client.js
@@ -231,6 +231,7 @@ client.socket.on('add', function(props) {
 
       if (broadcast !== false) {
         client.socket.emit('change', {
+          room: client.room,
           id: props.id,
           transform: transform
         });

--- a/js/controls.js
+++ b/js/controls.js
@@ -37,6 +37,7 @@ function createShape(ev) {
   // Send to ALL clients including self. It doesn't immediately add a shape to
   // your DOM, the 'add' socket listener that part.
   client.socket.emit('add', {
+    room: client.room,
     id: 'shape-' + Math.floor(Math.random() * 1000000000),
     class: this.dataset.shape,
     opacity: this.dataset.opacity,

--- a/js/socket.js
+++ b/js/socket.js
@@ -9,6 +9,17 @@ var client = function() {
   var room = window.location.origin;
   this.socket = io().connect(room);
 
+  // Warn when the connection is lost.
+  this.socket.on('disconnect', function (data) {
+    console.warn('You\'re disconnected!');
+  });
+
+  // When connection is finally re-stablished, join the bustashape room.
+  this.socket.on('reconnect', function (data) {
+    console.info('Reconnecting...');
+    join();
+  });
+
   this.socket.on('user-joined', function(data) {
     var evt = createEvent('user-joined');
     evt.nick = data.nick;


### PR DESCRIPTION
Socket.io automatically re-establishes a basic connection, but the rooms were not being rejoined. This branch ensures that the room is rejoined and users can continue participating in a room without refreshing the page.

This also means the server can die/reboot without disrupting anything too! 👍 

This also finishes laying the groundwork for #80 
