### PR TITLE
Non-touch canvas zoom/panning

### DIFF
--- a/js/canvas.js
+++ b/js/canvas.js
@@ -115,9 +115,87 @@ if (Modernizr.touchevents) {
   }
 }
 
-// Touch events are not detected.
+// Touch events are not detected. Set up some keyCode listeners to make it nicer
+// for projection and other public displays.
 else {
+  if (debug_busta === true) {
+    console.debug('💻 No touch events detected. Setting up projection mode.');
+  }
 
+  // We have to set up two event listeners because the `-` and `=` keys report
+  // different values across different browsers inside the `keypress` event, and
+  // additionally, Chrome doesn't fire the listeners for arrow keys on `keydown`
+  // event listeners.
+
+  // Pan handler. heh.
+  document.addEventListener('keydown', function handleProjectorPan(e) {
+    var key = e.which || e.keyCode;
+
+    if (!!window.logged_in) {
+      switch (key) {
+
+        // Left arrow.
+        case 37:
+          scene_transform.x -= (e.shiftKey) ? 100 : 10;
+          break;
+
+        // Right arrow.
+        case 39:
+          scene_transform.x += (e.shiftKey) ? 100 : 10;
+          break;
+
+        // Up arrow.
+        case 38:
+          scene_transform.y -= (e.shiftKey) ? 100 : 10;
+          break;
+
+        // Down arrow.
+        case 40:
+          scene_transform.y += (e.shiftKey) ? 100 : 10;
+          break;
+      }
+
+      // Update screen.
+      redrawCanvasPan();
+    }
+  });
+
+  // Zoom handler.
+  document.addEventListener('keypress', function handleProjectorZoom(e) {
+    var key = e.which || e.keyCode;
+
+    if (!!window.logged_in) {
+      switch (key) {
+
+        // Zoom in
+        case 45:
+          scene_transform.scale /= 1.08;
+          break;
+        case 95: // [Shift]
+          scene_transform.scale /= 2;
+          break;
+
+        // Zoom out
+        case 61:
+          scene_transform.scale *= 1.08;
+          break;
+        case 43: // [Shift]
+          scene_transform.scale *= 2;
+          break;
+      }
+
+      // Limit scaling to avoid getting lost.
+      if (scene_transform.scale < 1 / ZOOM_LIMIT) {
+        scene_transform.scale = 1 / ZOOM_LIMIT;
+      }
+      if (scene_transform.scale > ZOOM_LIMIT) {
+        scene_transform.scale = ZOOM_LIMIT;
+      }
+
+      // Update screen.
+      redrawCanvasPan();
+    }
+  });
 }
 
 /*

--- a/js/client.js
+++ b/js/client.js
@@ -133,8 +133,6 @@ client.socket.on('add', function(props) {
     ev.preventDefault();
 
     if (ev.type === 'panstart') {
-      // The first time any shape moves, it needs this class removed.
-      el.classList.remove('unchanged');
       // Change cursor on screens that have one.
       el.classList.add('grabbing');
 
@@ -271,9 +269,6 @@ client.socket.on('add', function(props) {
    */
   client.socket.on('change', function(props) {
     if (props.id === el.id) {
-      // In case this is the first time the shape has moved, remove this class.
-      el.classList.remove('unchanged');
-
       // Transform and animate the shape.
       transform = props.transform;
       requestElementUpdate(false);

--- a/js/controls.js
+++ b/js/controls.js
@@ -82,7 +82,10 @@ if (Modernizr.atobbtoa && Modernizr.adownload && !Modernizr.touchevents) {
 
       // Only react to the `s` key, and only do it if we've joined a room.
       if (!!window.logged_in && key === 115) {
+        // Prep the SVG for download.
         saveCanvas();
+
+        // Trigger download immediately.
         $('#save').click();
         return;
       }
@@ -93,13 +96,13 @@ if (Modernizr.atobbtoa && Modernizr.adownload && !Modernizr.touchevents) {
 // Take contents of canvas and encode them into save button so they can be
 // downloaded. The click or keypress event handles the button triggering.
 function saveCanvas() {
-  // Generate SVG
+  // Generate SVG.
   var save_button = $('#save');
   var save_svg = $('#canvas').innerHTML.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
   var data_uri = 'data:image/svg+xml;base64,' + window.btoa(save_svg);
   var filename = 'bustashape-' + window.location.hash.replace('#', '') + '-' + Date.now() + '.svg';
 
-  // Download SVG
+  // Prep link for new download.
   save_button.setAttribute('href', data_uri);
   save_button.setAttribute('download', filename);
 }

--- a/js/controls.js
+++ b/js/controls.js
@@ -76,15 +76,17 @@ if (Modernizr.atobbtoa && Modernizr.adownload && !Modernizr.touchevents) {
   save_button.on('click', saveCanvas);
 
   // Listen for `s` key
-  window.onload = function(){
-    document.onkeypress = function(e) {
-      var key = e.keyCode || e.which;
+  window.onload = function() {
+    document.addEventListener('keypress', function handleSaveCommands(e) {
+      var key = e.which || e.keyCode;
+
+      // Only react to the `s` key, and only do it if we've joined a room.
       if (!!window.logged_in && key === 115) {
         saveCanvas();
         $('#save').click();
         return;
       }
-    };
+    });
   };
 }
 

--- a/sass/partials/_shapes.scss
+++ b/sass/partials/_shapes.scss
@@ -1,13 +1,9 @@
 //------------------------------------------------------------------------------
 // Shapes
 //------------------------------------------------------------------------------
-
-//
-// Unchanged
-//
-// When a new shape appears it is "unchanged"
-// until being touched for the first time.
-.unchanged {
+.shape {
+  cursor: grab;
+  cursor: -webkit-grab;
 }
 
 //
@@ -15,4 +11,5 @@
 //
 .grabbing {
   cursor: grabbing;
+  cursor: -webkit-grabbing;
 }


### PR DESCRIPTION
Right now the canvas can only be zoomed and panned with touch devices. However the laptop is normally the projection device and it would be great to be able to zoom and pan there too.

I think instead of re-implementing the same code with the mouse (which can't do multitouch so zooming is more complicated) we should just set up hot buttons
- ⬅ ⬆ ⬇ ➡ for panning
- `-` and `+` for zoom
- `Shift` increments by 10/100x
